### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,7 +5,7 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-Scheduler KEYWORD1
+Scheduler	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
@@ -20,7 +20,7 @@ removeService	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-SERVICES_COUNT  LITERAL1
-PERIOD_MODE     LITERAL1
-COUNT_MODE      LITERAL1
-AS_FAST_AS_POS  LITERAL1
+SERVICES_COUNT	LITERAL1
+PERIOD_MODE	LITERAL1
+COUNT_MODE	LITERAL1
+AS_FAST_AS_POS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords